### PR TITLE
Less rails bootstrap 5.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,21 +1,11 @@
-appraise "rails31" do
-  gem "rails", "~> 3.1.12"
-  gem "minitest", "~> 4.7.5"
-end if RUBY_VERSION < '2.0.0'
-
-appraise "rails32" do
-  gem "rails", "~> 3.2.17"
-  gem "minitest", "~> 4.7.5"
+appraise 'rails50' do
+  gem 'rails', '~> 5.0.3'
 end
 
-appraise "rails40" do
-  gem "rails", "~> 4.0.4"
+appraise 'rails51' do
+  gem 'rails', '~> 5.1.1'
 end
 
-appraise "rails41" do
-  gem "rails", "~> 4.1.0"
-end
-
-appraise "rails42" do
-  gem "rails", "~> 4.2.0"
+appraise 'rails52' do
+  gem 'rails', '~> 5.2.4'
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Here are the steps to update the version of twitter bootstrap used.
 * Run the tests by doing:
 
 ```
-$ bundle install
-$ bundle exec rake appraisal:setup
-$ bundle exec rake appraisal test
+$ bundle
+$ bundle exec appraisal install
+$ bundle exec appraisal rake
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 gem 'sprockets', '~>3.0'
-gem "therubyracer", "~> 0.12.0", :require => nil, :platforms => :ruby
-gem "therubyrhino", "~> 2.0.2", :require => nil, :platforms => :jruby
+gem 'therubyracer', '~> 0.12.0', :require => nil, :platforms => :ruby
+gem 'therubyrhino', '~> 2.0.2', :require => nil, :platforms => :jruby
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
-
+gem 'sprockets', '~>3.0'
 gem "therubyracer", "~> 0.12.0", :require => nil, :platforms => :ruby
 gem "therubyrhino", "~> 2.0.2", :require => nil, :platforms => :jruby
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "therubyracer", ">= 0.10.1", :require => nil, :platforms => :ruby
-gem "therubyrhino", ">= 1.73.2", :require => nil, :platforms => :jruby
+gem "therubyracer", "~> 0.12.0", :require => nil, :platforms => :ruby
+gem "therubyrhino", "~> 2.0.2", :require => nil, :platforms => :jruby
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bootstrap is Twitter's toolkit for kickstarting your site or app's CSS. It includes base styles for typography, forms, buttons, tables, grid layout, navigation, alerts, and more. To get started -- check out the [Bootstrap docs](http://getbootstrap.com/).
 
-The less-rails-bootstrap project hooks into [less-rails](http://github.com/metaskills/less-rails) and [less.rb](http://github.com/cowboyd/less.rb), making Bootstrap's source LESS files, compiled CSS, and JavaScript files available in the Rails 3.x and 4.x asset pipeline.
+The less-rails-bootstrap project hooks into [less-rails](http://github.com/metaskills/less-rails) and [less.rb](http://github.com/cowboyd/less.rb), making Bootstrap's source LESS files, compiled CSS, and JavaScript files available in the Rails 4.x and 5.x asset pipeline.
 
 The benefits:
 
@@ -87,18 +87,18 @@ This gem will directly track the semantic versioning of the Twitter Bootstrap pr
 
 ## Contributing
 
-This gem is fully tested from Rails 3.1 to 4.1. We run our tests on [Travis CI](http://travis-ci.org/metaskills/less-rails-boostrap) in both Ruby 1.9, 2.0, 2.1, and jRuby 1.9 mode. If you detect a problem, open up a github issue or fork the repo and help out. After you fork or clone the repository, the following commands will get you up and running on the test suite.
+This gem is fully tested from Rails 4.0 to 5.2. We run our tests on [Travis CI](http://travis-ci.org/metaskills/less-rails-boostrap) in both Ruby 1.9, 2.0  and jRuby 9000. If you detect a problem, open up a github issue or fork the repo and help out. After you fork or clone the repository, the following commands will get you up and running on the test suite.
 
 ```shell
-$ bundle install
+$ bundle
 $ bundle exec appraisal install
-$ bundle exec appraisal rake test
+$ bundle exec appraisal test
 ```
 
-We use the [appraisal](https://github.com/thoughtbot/appraisal) gem from Thoughtbot to help us generate the individual gemfiles for each Rails version and to run the tests locally against each generated Gemfile. The `appraisal rake test` command actually runs our test suite against all Rails versions in our `Appraisal` file. If you want to run the tests for a specific Rails version, use `rake -T` for a list. For example, the following command will run the tests for Rails 3.2 only.
+We use the [appraisal](https://github.com/thoughtbot/appraisal) gem from Thoughtbot to help us generate the individual gemfiles for each Rails version and to run the tests locally against each generated Gemfile. The `appraisal test` command actually runs our test suite against all Rails versions in our `Appraisal` file. If you want to run the tests for a specific Rails version, use `rake -T` for a list. For example, the following command will run the tests for Rails 4.0 only.
 
 ```shell
-$ bundle exec appraisal rails32 rake test
+$ bundle exec appraisal rails40 rake test
 ```
 
 Our current build status is:
@@ -125,6 +125,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Less::Rails is Copyright (c) 2011 Ken Collins, <ken@metaskills.net> and is distributed under the MIT license.
-
-
-

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This gem will directly track the semantic versioning of the Twitter Bootstrap pr
 
 ## Contributing
 
-This gem is fully tested for Rails 5.2. We run our tests on [Travis CI](http://travis-ci.org/metaskills/less-rails-boostrap) in both Ruby 1.9, 2.0 and jRuby 9000. If you detect a problem, open up a github issue or fork the repo and help out. After you fork or clone the repository, the following commands will get you up and running on the test suite.
+This gem is fully tested for Rails 5.0 to 5.2. If you detect a problem, open up a github issue or fork the repo and help out. After you fork or clone the repository, the following commands will get you up and running on the test suite.
 
 ```shell
 $ bundle

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bootstrap is Twitter's toolkit for kickstarting your site or app's CSS. It includes base styles for typography, forms, buttons, tables, grid layout, navigation, alerts, and more. To get started -- check out the [Bootstrap docs](http://getbootstrap.com/).
 
-The less-rails-bootstrap project hooks into [less-rails](http://github.com/metaskills/less-rails) and [less.rb](http://github.com/cowboyd/less.rb), making Bootstrap's source LESS files, compiled CSS, and JavaScript files available in the Rails 4.x and 5.x asset pipeline.
+The less-rails-bootstrap project hooks into [less-rails](http://github.com/metaskills/less-rails) and [less.rb](http://github.com/cowboyd/less.rb), making Bootstrap's source LESS files, compiled CSS, and JavaScript files available in the Rails 5.x asset pipeline.
 
 The benefits:
 
@@ -87,18 +87,18 @@ This gem will directly track the semantic versioning of the Twitter Bootstrap pr
 
 ## Contributing
 
-This gem is fully tested from Rails 4.0 to 5.2. We run our tests on [Travis CI](http://travis-ci.org/metaskills/less-rails-boostrap) in both Ruby 1.9, 2.0  and jRuby 9000. If you detect a problem, open up a github issue or fork the repo and help out. After you fork or clone the repository, the following commands will get you up and running on the test suite.
+This gem is fully tested for Rails 5.2. We run our tests on [Travis CI](http://travis-ci.org/metaskills/less-rails-boostrap) in both Ruby 1.9, 2.0 and jRuby 9000. If you detect a problem, open up a github issue or fork the repo and help out. After you fork or clone the repository, the following commands will get you up and running on the test suite.
 
 ```shell
 $ bundle
 $ bundle exec appraisal install
-$ bundle exec appraisal test
+$ bundle exec appraisal rake
 ```
 
-We use the [appraisal](https://github.com/thoughtbot/appraisal) gem from Thoughtbot to help us generate the individual gemfiles for each Rails version and to run the tests locally against each generated Gemfile. The `appraisal test` command actually runs our test suite against all Rails versions in our `Appraisal` file. If you want to run the tests for a specific Rails version, use `rake -T` for a list. For example, the following command will run the tests for Rails 4.0 only.
+We use the [appraisal](https://github.com/thoughtbot/appraisal) gem from Thoughtbot to help us generate the individual gemfiles for each Rails version and to run the tests locally against each generated Gemfile. The `appraisal test` command actually runs our test suite against all Rails versions in our `Appraisal` file. If you want to run the tests for a specific Rails version, use `rake -T` for a list. For example, the following command will run the tests for Rails 5.0 only.
 
 ```shell
-$ bundle exec appraisal rails40 rake test
+$ bundle exec appraisal rails50 rake test
 ```
 
 Our current build status is:

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,7 @@
-require 'bundler'
+require 'rubygems'
+require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'appraisal'
-
-Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new do |t|
   t.libs = ['lib','test']

--- a/less-rails-bootstrap.gemspec
+++ b/less-rails-bootstrap.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
-  gem.add_runtime_dependency     'less-rails', ['>= 2.6', '<= 2.8']
+  gem.add_runtime_dependency     'less-rails', '>= 3.0'
 
   gem.add_development_dependency 'minitest', '>= 4.0'
   gem.add_development_dependency 'guard-minitest'
   gem.add_development_dependency 'guard'
-  gem.add_development_dependency 'rails',  ['>= 3.1', '<= 4.2']
+  gem.add_development_dependency 'rails',  '>= 5.0'
   gem.add_development_dependency 'appraisal'
 end

--- a/test/cases/engine_spec.rb
+++ b/test/cases/engine_spec.rb
@@ -9,8 +9,5 @@ class EngineSpec < Less::Rails::Bootstrap::Spec
   it 'must append engines assets stylesheets to less-rails load paths' do
     assert_instance_of Array, dummy_config.less.paths
     assert_includes dummy_config.less.paths, project_app_twitter_bootstrap
-
   end
-  
-
 end

--- a/test/cases/engine_spec.rb
+++ b/test/cases/engine_spec.rb
@@ -3,12 +3,13 @@ require 'spec_helper'
 class EngineSpec < Less::Rails::Bootstrap::Spec
   
   it 'must be able to hook into a less-rails config' do
-    dummy_config.less.must_be_instance_of ActiveSupport::OrderedOptions
+    assert_instance_of ActiveSupport::OrderedOptions, dummy_config.less
   end
   
   it 'must append engines assets stylesheets to less-rails load paths' do
-    dummy_config.less.paths.must_be_instance_of Array
-    dummy_config.less.paths.must_include project_app_twitter_bootstrap
+    assert_instance_of Array, dummy_config.less.paths
+    assert_includes dummy_config.less.paths, project_app_twitter_bootstrap
+
   end
   
 

--- a/test/cases/usage_css_spec.rb
+++ b/test/cases/usage_css_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 class UsageCssSpec < Less::Rails::Bootstrap::Spec
 
@@ -12,7 +11,7 @@ class UsageCssSpec < Less::Rails::Bootstrap::Spec
     end
 
     it 'must include basic css afterward' do
-      assert_includes app_css,  '#other-css { color: red; }',  'From our code afterward.'
+      assert_includes app_css, '#other-css { color: red; }',  'From our code afterward.'
     end
 
   end
@@ -31,11 +30,11 @@ class UsageCssSpec < Less::Rails::Bootstrap::Spec
     before { dummy_config.less.compress = true }
 
     let(:framework_css) { dummy_asset('framework.css') }
-   
+
     it 'will render bootstrap functions' do
       border_radius_line = line_for_framework_css('framework-box-shadow')
-      assert_includes border_radius_line,  '-webkit-box-shadow:4px'
-      assert_includes border_radius_line,  'box-shadow:4px'
+      assert_includes border_radius_line, '-webkit-box-shadow:4px'
+      assert_includes border_radius_line, 'box-shadow:4px'
     end
 
     it 'will render bootstrap variables' do

--- a/test/cases/usage_css_spec.rb
+++ b/test/cases/usage_css_spec.rb
@@ -1,18 +1,18 @@
 require 'spec_helper'
+require 'pry'
 
 class UsageCssSpec < Less::Rails::Bootstrap::Spec
 
   describe 'application.css' do
-
     let(:app_css) { dummy_asset('application.css') }
 
     it 'will render main bootstrap.less file and all included modules' do
-      app_css.must_include '.text-center' # From type.less
-      app_css.must_include '.panel-default' # From panels.less
+      assert_includes app_css, '.text-center' # From type.less
+      assert_includes app_css, '.panel-default' # From panels.less
     end
 
     it 'must include basic css afterward' do
-      app_css.must_include '#other-css { color: red; }',  'From our code afterward.'
+      assert_includes app_css,  '#other-css { color: red; }',  'From our code afterward.'
     end
 
   end
@@ -22,26 +22,25 @@ class UsageCssSpec < Less::Rails::Bootstrap::Spec
     let(:app_css) { dummy_asset('fonts.css.less') }
 
     it 'uses less-rails asset-url helper for fonts' do
-      app_css.must_include "/assets/twitter/bootstrap/glyphicons-halflings-regular"
+      assert_includes app_css,  "/assets/twitter/bootstrap/glyphicons-halflings-regular"
     end
 
   end
 
   describe 'framework.css.less' do
-
     before { dummy_config.less.compress = true }
 
     let(:framework_css) { dummy_asset('framework.css') }
-
+   
     it 'will render bootstrap functions' do
       border_radius_line = line_for_framework_css('framework-box-shadow')
-      border_radius_line.must_include '-webkit-box-shadow:4px'
-      border_radius_line.must_include 'box-shadow:4px'
+      assert_includes border_radius_line,  '-webkit-box-shadow:4px'
+      assert_includes border_radius_line,  'box-shadow:4px'
     end
 
     it 'will render bootstrap variables' do
       link_color_line = line_for_framework_css('framework-linkColor')
-      link_color_line.must_include 'color:#337ab7'
+      assert_includes link_color_line, 'color:#337ab7'
     end
 
   end
@@ -54,10 +53,9 @@ class UsageCssSpec < Less::Rails::Bootstrap::Spec
 
     it 'will render bootstrap variables and mixins' do
       my_button_line = line_for_individual_css('individual-my-button')
-      my_button_line.must_include '-webkit-box-shadow:10px'
-      my_button_line.must_include 'box-shadow:10px'
+      assert_includes my_button_line, '-webkit-box-shadow:10px'
+      assert_includes my_button_line, 'box-shadow:10px'
     end
-
   end
 
 

--- a/test/cases/usage_js_spec.rb
+++ b/test/cases/usage_js_spec.rb
@@ -10,7 +10,7 @@ class UsageJsSpec < Less::Rails::Bootstrap::Spec
       files = ['affix', 'alert', 'button', 'carousel', 'collapse', 'dropdown', 'modal',
                'popover', 'scrollspy', 'tab', 'tooltip', 'transition']
       files.each do |file|
-        assert_includes app_js,  "#{file}.js"
+        assert_includes app_js, "#{file}.js"
       end
     end
     

--- a/test/cases/usage_js_spec.rb
+++ b/test/cases/usage_js_spec.rb
@@ -10,12 +10,12 @@ class UsageJsSpec < Less::Rails::Bootstrap::Spec
       files = ['affix', 'alert', 'button', 'carousel', 'collapse', 'dropdown', 'modal',
                'popover', 'scrollspy', 'tab', 'tooltip', 'transition']
       files.each do |file|
-        app_js.must_include "#{file}.js"
+        assert_includes app_js,  "#{file}.js"
       end
     end
     
     it 'must include basic js afterward' do
-      app_js.must_include '$(document).ready(function(){...});'
+      assert_includes app_js, '$(document).ready(function(){...});'
     end
     
   end
@@ -25,10 +25,8 @@ class UsageJsSpec < Less::Rails::Bootstrap::Spec
     let(:individual_js) { dummy_asset('individual.js') }
     
     it 'will render bootstrap variables and mixins' do
-      individual_js.must_include 'modal.js'
+      assert_includes individual_js, 'modal.js'
     end
     
   end
-
-
 end


### PR DESCRIPTION
This pull request includes the pull request made by veelenga at 
https://github.com/metaskills/less-rails-bootstrap/pull/132 to upgrade to the gem to rails 5.1. 
We are currently pointed to that  pull request since its no longer being maintained and has not be merged. 

In addition this pull request has upgraded to rails 5.2. 
Upgrade gem to rails 5.2